### PR TITLE
Fix subsetLiger() cell.data copying when subsetting before clustering.

### DIFF
--- a/R/liger.R
+++ b/R/liger.R
@@ -4890,8 +4890,9 @@ subsetLiger <- function(object, clusters.use = NULL, cells.use = NULL, remove.mi
   a@tsne.coords <- object@tsne.coords[names(a@clusters), ]
   a@H.norm <- object@H.norm[names(a@clusters), ]
   # Add back additional cell.data
+  cell.nms <- unname(unlist(lapply(a@raw.data, colnames)))
   if (ncol(a@cell.data) < ncol(object@cell.data)) {
-    a@cell.data <- droplevels(data.frame(object@cell.data[names(a@clusters), ]))
+    a@cell.data <- droplevels(data.frame(object@cell.data[cell.nms, ]))
   }
   
   a@W <- object@W

--- a/R/liger.R
+++ b/R/liger.R
@@ -4885,10 +4885,9 @@ subsetLiger <- function(object, clusters.use = NULL, cells.use = NULL, remove.mi
   a@H <- lapply(1:length(a@raw.data), function(i) {
     object@H[[nms[i]]][colnames(a@raw.data[[i]]), ]
   })
-  cell.nms <- unname(unlist(lapply(a@raw.data, colnames)))
-  a@clusters <- object@clusters[cell.nms]
+  a@clusters <- object@clusters[unlist(lapply(a@H, rownames))]
   a@clusters <- droplevels(a@clusters)
-  a@tsne.coords <- object@tsne.coords[cell.nms, ]
+  a@tsne.coords <- object@tsne.coords[names(a@clusters), ]
   a@H.norm <- object@H.norm[names(a@clusters), ]
   # Add back additional cell.data
   cell.nms <- unname(unlist(lapply(a@raw.data, colnames)))


### PR DESCRIPTION
The current implementation of subsetLiger() deletes everything in the cell.data slot when subsetting a liger object that has no data in the clusters slot.

This is because of the following line:
https://github.com/MacoskoLab/liger/blob/2532a37e0af6b5a13f821c7e8d2cdc9945fcdf9e/R/liger.R#L4894
It also causes the show method to report "0 total cells" for the subset.

This can be fixed by getting the cell names for the subsetting of the cell data e.g. from the raw.data slot .