### PR TITLE
Fix subsetLiger removing cell.data and reporting 0 cells when no clustering available.

### DIFF
--- a/R/rliger.R
+++ b/R/rliger.R
@@ -6505,9 +6505,10 @@ subsetLiger <- function(object, clusters.use = NULL, cells.use = NULL, remove.mi
   a@clusters <- droplevels(a@clusters)
   a@tsne.coords <- object@tsne.coords[names(a@clusters), ]
   a@H.norm <- object@H.norm[names(a@clusters), ]
+  cell.names <- unname(unlist(lapply(a@raw.data, colnames)))
   # Add back additional cell.data
   if (ncol(a@cell.data) < ncol(object@cell.data)) {
-    a@cell.data <- droplevels(data.frame(object@cell.data[names(a@clusters), ]))
+    a@cell.data <- droplevels(data.frame(object@cell.data[cell.names, ]))
   }
 
   a@W <- object@W


### PR DESCRIPTION
Dear rliger team,

The current implementation of subsetLiger() deletes everything in the cell.data slot when subsetting a liger object that has no data in the clusters slot.

This is because of the following line:
https://github.com/welch-lab/liger/blob/89b24437c1cee798d4efbf7f9f9d8c301e59d74a/R/rliger.R#L6510
Here, the cell.data slot is subsetted by the names of a@cluster, which is of course empty if subsetLiger() is called before clustering.

It also causes the show method to report "0 total cells" for the subset.

This error can be very frustrating, as there are also no warnings.

It can be fixed by getting the cell names for the subsetting of the cell data e.g. from the raw.data slot. As in:

```r
cell.names <- unname(unlist(lapply(a@raw.data, colnames)))
  if (ncol(a@cell.data) < ncol(object@cell.data)) {
    a@cell.data <- droplevels(data.frame(object@cell.data[cell.names, ]))
  }
```

I think should be a very small and easy change. This was already present in liger 0.5.0, and I had created a pull request also then. I've created this new pull request for the current version of rliger to make it easier to merge.

Best regards and thanks for the great package!
Nils