### PR TITLE
Bug in getProportionMito

### DIFF
--- a/R/rliger.R
+++ b/R/rliger.R
@@ -4587,7 +4587,7 @@ getProportionMito <- function(object, use.norm = FALSE) {
     data.use <- object@norm.data
   }
   percent_mito <- unlist(lapply(unname(data.use), function(x) {
-    colSums(x[mito.genes, ]) / colSums(x)
+    colSums(x[rownames(x) %in% mito.genes, ]) / colSums(x)
   }), use.names = TRUE)
   
   return(percent_mito)


### PR DESCRIPTION
I noticed that getProportionMito gives an uninformative error (about indexing) if all mitochondrial genes found are not shared across all datasets. Using %in% instead of indexing ought to correct that.