### PR TITLE
Fixed non-conformable matrix bug in online_iNMF

### DIFF
--- a/R/rliger.R
+++ b/R/rliger.R
@@ -1862,7 +1862,7 @@ online_iNMF <- function(object,
       object@A[(num_prev_files+1):num_files] = rep(list(matrix(0, k, k)), num_new_files)
       object@B[(num_prev_files+1):num_files] = rep(list(matrix(0, num_genes, k)), num_new_files)
       A_old[(num_prev_files+1):num_files] = rep(list(matrix(0, k, k)), num_new_files) # save information older than 2 epochs
-      B_old[(num_prev_files+1):num_files] = rep(list(matrix(0, k, k)), num_new_files) # save information older than 2 epochs
+      B_old[(num_prev_files+1):num_files] = rep(list(matrix(0, num_genes, k)), num_new_files) # save information older than 2 epochs
     }
     
     iter = 1


### PR DESCRIPTION
Hi, I noticed that when running online_iNMF I was getting a non-conformable matrix error with regard to `object@B[[i]] - B_old[[i]]`. I think this is due to the line initializing B_old when X_new is specified; the dimensions of the matrix are different than when X_new is left NULL. Changing the matrix dimensions to `(num_genes, k)` seems to fix the error. Thanks so much for this package!