### PR TITLE
fix setting default

### DIFF
--- a/R/embedding.R
+++ b/R/embedding.R
@@ -82,6 +82,7 @@ runUMAP <- function(
                        min_dist = minDist)
     if (isTRUE(verbose)) cli::cli_process_done()
     dimRed(object, dimredName) <- umap
+    defaultDimRed(object) <- dimredName
     if (isTRUE(verbose))
         cli::cli_alert_info("{.field DimRed} {.val {dimredName}} is now set as default.")
     return(object)
@@ -184,6 +185,7 @@ runTSNE <- function(
     }
     if (isTRUE(verbose)) cli::cli_process_done()
     dimRed(object, dimredName) <- tsne
+    defaultDimRed(object) <- dimredName
     object@uns$TSNE <- list(method = method)
     if (isTRUE(verbose))
         cli::cli_alert_info("{.field DimRed} {.val {dimredName}} is now set as default.")


### PR DESCRIPTION
Hi LIGER team,

Just quick PR here to fix issue.  Right now runTSNE and runUMAP don't appropriately update the default dim reduc when a dimreduc is already present in object (for instance if seurat object with reductions is converted to liger object).  This PR just adds single line to each of the functions to explicitly update the dim reduc after being run.

Thanks!
Sam